### PR TITLE
Hopefully fixed an issue with the requirejs build

### DIFF
--- a/src/assets/Gruntfile.js
+++ b/src/assets/Gruntfile.js
@@ -289,7 +289,8 @@ module.exports = function (grunt) {
                     mainConfigFile: "source/scripts/main.js",
                     out: "<%= serlo.tmp %>/scripts/main.js",
                     preserveLicenseComments: false,
-                    optimize: 'none'
+                    optimize: 'none',
+                    _buildPathToModuleIndex: {}
                 }
             },
             testing: {
@@ -299,7 +300,8 @@ module.exports = function (grunt) {
                     mainConfigFile: "source/tests/modules/specRunner.js",
                     out: "<%= serlo.tmp %>/scripts/main.js",
                     preserveLicenseComments: false,
-                    optimize: 'none'
+                    optimize: 'none',
+                    _buildPathToModuleIndex: {}
                 }
             }
         },

--- a/src/assets/package.json
+++ b/src/assets/package.json
@@ -19,7 +19,7 @@
         "grunt-bower-install"    : "~0.5.0",
         "grunt-contrib-imagemin" : "~0.1.0",
         "grunt-contrib-watch"    : "~0.5.2",
-        "grunt-contrib-requirejs": "~0.4.1",
+        "grunt-contrib-requirejs": "~0.4.4",
         "grunt-rev"              : "~0.1.0",
         "grunt-autoprefixer"     : "~0.2.0",
         "grunt-usemin"           : "~0.1.10",

--- a/src/assets/source/scripts/ATHENE2.js
+++ b/src/assets/source/scripts/ATHENE2.js
@@ -11,7 +11,7 @@
 define("ATHENE2", ['jquery', 'common', 'side_navigation', 'translator', 'side_element', 'content', 'search', 'system_notification',
                    'moment', 'ajax_overlay', 'tracking', 'toggle_action', 'modals', 'trigger', 'sortable_list',
                    'timeago', 'spoiler', 'injections', 'moment_de', 'mathjax_trigger', 'affix', 'forum_select', 'slider',
-                   'magnific_popup'
+                   'magnific_popup', 'easing', 'nestable', 'historyjs', 'polyfills', 'datepicker', 'event_extensions', 'jasny'
 ],
     function (
         $, Common, SideNavigation, t, SideElement, Content, Search, SystemNotification, moment, AjaxOverlay,

--- a/src/assets/source/scripts/main.js
+++ b/src/assets/source/scripts/main.js
@@ -71,9 +71,6 @@ require.config({
         },
         historyjs: {
             deps: ['jquery']
-        },
-        ATHENE2: {
-            deps: ['bootstrap', 'easing', 'nestable', 'historyjs', 'polyfills', 'datepicker', 'event_extensions', 'jasny']
         }
     },
     waitSeconds: 2


### PR DESCRIPTION
Note that I've tested this with grunt-cli v0.1.13

The Error

```
{ [Error: Error: Module loading did not complete for: ATHENE2, easing
    at Function.build.checkForErrors (/Users/ju/workspace/serlo/athene2/src/assets/node_modules/grunt-contrib-requirejs/node_modules/requirejs/bin/r.js:28424:19)
]
  originalError: [Error: Module loading did not complete for: ATHENE2, easing] }
```

appeared very randomly, so this might not fix it at all.