### PR TITLE
Add aliases for used social icons

### DIFF
--- a/src/assets/source/styles/_shame.scss
+++ b/src/assets/source/styles/_shame.scss
@@ -88,3 +88,11 @@ svg {
   max-width: 100%;
   height: auto;
 }
+
+// Trick Fanboy Social List, see https://github.com/FortAwesome/Font-Awesome/issues/1799#issuecomment-50438859
+.fa-social-icon-tw:before {
+  content: "\f081";
+}
+.fa-social-icon-fb:before {
+  content: "\f082";
+}


### PR DESCRIPTION
The `icon` parameter have to be updated in the navigation `social` as soon as this PR is live.