### PR TITLE
Fix twig-gettext-extractor

### DIFF
--- a/bin/twig-gettext-extractor
+++ b/bin/twig-gettext-extractor
@@ -122,6 +122,9 @@ $twig->addFunction(new \Twig_SimpleFunction('preview', true));
 $twig->addFunction(new \Twig_SimpleFunction('search', true));
 $twig->addFunction(new \Twig_SimpleFunction('isGranted', true));
 
+$twig->addFunction(new \Twig_SimpleFunction('headlink', true));
+$twig->addFunction(new \Twig_SimpleFunction('user', true));
+
 array_shift($_SERVER['argv']);
 $addTemplate = false;
 


### PR DESCRIPTION
Our `twig-gettext-extractor` script didn't work anymore. Seems like there are some new view helpers that weren't covered in the script.