### PR TITLE
Improve creating of revisions

### DIFF
--- a/src/assets/source/styles/base/_variables.scss
+++ b/src/assets/source/styles/base/_variables.scss
@@ -45,7 +45,7 @@ $serloGray: #404040;
  */
 $serloBlueLight:            lighten($serloBlue, 35%);
 $serloBlueAlternativeLight: lighten($serloBlueAlternative, 35%);
-$serloGreenLight:           lighten($serloGreen, 35%);
+$serloGreenLight:           #b4e11f;
 $serloGrayLight:            lighten($serloGray, 35%);
 
 

--- a/src/assets/source/styles/partials/_bootstrap_extension.scss
+++ b/src/assets/source/styles/partials/_bootstrap_extension.scss
@@ -241,3 +241,7 @@ hr {
     display: none;
   }
 }
+
+.label-community-light {
+  background-color: $serloGreenLight;
+}

--- a/src/module/Entity/config/route.config.php
+++ b/src/module/Entity/config/route.config.php
@@ -157,12 +157,13 @@ return [
                             'add-revision' => [
                                 'type'    => 'segment',
                                 'options' => [
-                                    'route'       => '/add-revision/:entity',
+                                    'route'       => '/add-revision/:entity[/:revision]',
                                     'defaults'    => [
                                         'action' => 'addRevision'
                                     ],
                                     'constraints' => [
-                                        'entity' => '[0-9]+'
+                                        'entity' => '[0-9]+',
+                                        'revision' => '[0-9]+'
                                     ]
                                 ]
                             ]

--- a/src/module/Entity/src/Entity/Controller/RepositoryController.php
+++ b/src/module/Entity/src/Entity/Controller/RepositoryController.php
@@ -39,7 +39,7 @@ class RepositoryController extends AbstractController
         $this->assertGranted('entity.revision.create', $entity);
 
         /* @var $form \Zend\Form\Form */
-        $form = $this->getForm($entity);
+        $form = $this->getForm($entity, $this->params('revision'));
         $view = new ViewModel(['entity' => $entity, 'form' => $form]);
 
         if ($this->getRequest()->isPost()) {
@@ -162,17 +162,18 @@ class RepositoryController extends AbstractController
      * @param EntityInterface $entity
      * @return Form
      */
-    protected function getForm(EntityInterface $entity)
+    protected function getForm(EntityInterface $entity, $id = null)
     {
         // Todo: Unhack
 
         $type = $entity->getType()->getName();
         $form = $this->moduleOptions->getType($type)->getComponent('repository')->getForm();
         $form = $this->getServiceLocator()->get($form);
+        $revision = $this->getRevision($entity, $id);
 
-        if ($entity->hasCurrentRevision()) {
+        if (is_object($revision)) {
             $data = [];
-            foreach ($entity->getCurrentRevision()->getFields() as $field) {
+            foreach ($revision->getFields() as $field) {
                 $data[$field->getName()] = $field->getValue();
             }
             $form->setData($data);

--- a/src/module/Ui/templates/entity/repository/history.twig
+++ b/src/module/Ui/templates/entity/repository/history.twig
@@ -13,6 +13,7 @@
         <th>{% trans %} Changes {% endtrans %}</th>
         <th>{% trans %} Author {% endtrans %}</th>
         <th>{% trans %} Timestamp {% endtrans %}</th>
+        <th></th>
     </tr>
     </thead>
     {% for revision in revisions %}
@@ -20,13 +21,20 @@
         <tr class="{{ isCurrent ? 'active ' : '' }}{{ revision.isTrashed() ? 'warning' : '' }}">
             <td>
                 {{ revision.getId() }}
-                (<a href="{{ url('entity/repository/compare', {'entity': entity.getId(), 'revision': revision.getId()}) }}">{% trans %}
-                    show {% endtrans %}</a>)
+                (<a href="{{ url('entity/repository/compare', {'entity': entity.getId(), 'revision': revision.getId()}) }}">
+                    {% trans %} show {% endtrans %}
+                </a>)
             </td>
             <td>{{ isCurrent ? '<span class="fa fa-check"></span>' : '' }}</td>
             <th>{{ revision.get('changes') }}</th>
             <td>{{ normalize().toAnchor(revision.getAuthor()) }}</td>
             <td>{{ timeago().render(revision.getTimestamp()) }}</td>
+            <td>
+                <a href="{{ url('entity/repository/add-revision', {'entity': entity.getId(), 'revision': revision.getId()}) }}"
+                   data-toggle="tooltip" title="{% trans %} Create a new revision starting from this specific revision {% endtrans %}">
+                    <span class="fa fa-pencil"></span>
+                </a>
+            </td>
         </tr>
     {% endfor %}
 </table>

--- a/src/module/Ui/templates/entity/view/partials/actions/versioning/edit-essential.twig
+++ b/src/module/Ui/templates/entity/view/partials/actions/versioning/edit-essential.twig
@@ -1,7 +1,11 @@
 {% set options = entity().getOptions(entity) %}
 {% if options.hasComponent('repository') %}
     <li>
+    {% if entity.isUnrevised() %}
+        <a rel="nofollow" href="{{ url('entity/repository/history', {'entity': entity.getId()}) }}">
+    {% else %}
         <a rel="nofollow" href="{{ url('entity/repository/add-revision', {'entity': entity.getId()}) }}">
+    {% endif %}
             <span class="fa fa-pencil"></span>
             {% trans %} Edit {% endtrans %}
         </a>

--- a/src/module/Ui/templates/entity/view/partials/actions/versioning/edit.twig
+++ b/src/module/Ui/templates/entity/view/partials/actions/versioning/edit.twig
@@ -1,6 +1,13 @@
 {% set options = entity().getOptions(entity) %}
 {% if options.hasComponent('repository') %}
-    <a rel="nofollow" class="btn btn-success" href="{{ url('entity/repository/add-revision', {'entity': entity.getId()}) }}">
-        <span class="fa fa-pencil"></span>
-    </a>
+    {% if entity.isUnrevised() %}
+        <a rel="nofollow" class="btn btn-success href="{{ url('entity/repository/history', {'entity': entity.getId()}) }}">
+            <span class="fa fa-clock-o"></span>
+            <span class="label label-community-light">{{ entity.countUnrevised() }}</span>
+        </a>
+    {% else %}
+        <a rel="nofollow" class="btn btn-success" href="{{ url('entity/repository/add-revision', {'entity': entity.getId()}) }}">
+            <span class="fa fa-pencil"></span>
+        </a>
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
Allow creating of revisions starting from any revision. Show edit button only if there is no unrevised revision. Show a button pointing to the history and labelled with the number of unrevised revisions.