### PR TITLE
Enable subdomains in local environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,4 +31,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     run "vagrant ssh -c 'sh /vagrant/bin/vagrant/boot.sh'"
     run "vagrant rsync-auto"
   end
+
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.aliases = %w(de.serlo.local en.serlo.local)
 end

--- a/src/config/autoload/local.php.dist
+++ b/src/config/autoload/local.php.dist
@@ -52,7 +52,7 @@ return [
         ]
     ],
     'instance'     => [
-        'strategy' => 'Instance\Strategy\CookieStrategy'
+        'strategy' => 'Instance\Strategy\DomainStrategy'
     ],
     'dbParams'     => array(
         'host'     => $dbParams['host'],


### PR DESCRIPTION
Needs [vagrant-hostmanager](https://github.com/smdahlen/vagrant-hostmanager):
```
vagrant plugin install vagrant-hostmanager
```
Note the change in `local.php.dist`, i.e. change your `local.php` beforehand. Also, `vagrant up`/`vagrant destroy` asks for a password because vagrant has to edit the `/etc/hosts` file (resp. its Windows pendant). Afterwards, de.serlo.local resp. en.serlo.local (no port needed :+1:) lead to the german resp. english development environment!

@arekkas Can you test if this also works on Windows? If it does, I also update the README/athene2-guide to reflect this change (and the changes beforehand). This PR does not include the changes to Gruntfile, since I want to refactor this changes. If you can an error, just remove the webcomponents parts...