### PR TITLE
Fix athene2-editor syncing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     :group => "vagrant",
     type: "rsync",
     rsync__auto: "true",
-    rsync__exclude: ["src/public/assets/", "composer.lock", ".idea/", "src/data/", "src/vendor/", "src/assets/build/", "src/assets/tmp/", "src/assets/source/bower_components", "src/assets/node_modules", "src/assets/athene2-editor/node_modules"],
+    rsync__exclude: [
+      "src/public/assets/",
+      "composer.lock",
+      ".idea/",
+      "src/data/",
+      "src/vendor/",
+      "src/assets/build/",
+      "src/assets/tmp/",
+      "src/assets/source/bower_components",
+      "src/assets/node_modules",
+      "src/assets/athene2-editor/build",
+      "src/assets/athene2-editor/tmp",
+      "src/assets/athene2-editor/source/bower_components",
+      "src/assets/athene2-editor/node_modules"
+    ],
     rsync__args: ["--verbose", "--archive", "--delete", "--stats"]
 
   config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
**tl;dr**: Basically adds some new rsync excludes for `src/assets/athene2-editor` similar to `src/assets` so that syncing doesn't interfere with `grunt dev` 