### PR TITLE
WIP Hide actions for trashed entities

### DIFF
--- a/src/module/Ui/templates/entity/page/article.twig
+++ b/src/module/Ui/templates/entity/page/article.twig
@@ -5,7 +5,7 @@
 {% include 'entity/page/partials/placeholders' %}
 <div itemscope itemtype="http://schema.org/Article">
     <div class="page-header">
-        {% set controls = include('entity/view/partials/actions/controls') %}
+        {% set controls = not entity.isTrashed() ? include('entity/view/partials/actions/controls') : '' %}
         {% do placeholder('controls').set(controls) %}
         {% do placeholder('isLeaf').set(true) %}
         {% do placeholder('breadcrumbs').set('<li><span>' ~ title ~ '</span></li>') %}

--- a/src/module/Ui/templates/entity/page/course-page.twig
+++ b/src/module/Ui/templates/entity/page/course-page.twig
@@ -1,16 +1,13 @@
-{% set title = entity.getCurrentRevision().get('title') %}
 {% set parent = entity.getParents('link').first() %}
 {% set title = normalize().toTitle(entity) %}
 {% do headTitle(title ~ ' - ' ~ entity().findSubject(parent) ~ ' ' ~ (entity.getType().getName() | trans)) %}
 {% do normalize().headMeta(entity) %}
+{% set controls = not entity.isTrashed() ? include('entity/view/partials/actions/course/course-controls-wrapper', {'entity': entity, 'parent': parent}): '' %}
 
-{% set controls = include('entity/view/partials/actions/course/course-controls-wrapper', {'entity': entity, 'parent': parent}) %}
 {% do placeholder('controls').set(controls) %}
 {% do placeholder('isLeaf').set(true) %}
 {% do placeholder('breadcrumbs').set('<li><a href="' ~ normalize().toUrl(parent) ~ '"><span>' ~ parent.getCurrentRevision().get('title') ~
 '</span></a></li> <li><span>'~title~'</span></li>') %}
-
-{% include 'entity/page/partials/alerts' %}
 {% include 'entity/view/default' %}
 
 {% set courseNav = include('entity/page/course-navigation', {'entity': parent, 'activePage': entity}) %}

--- a/src/module/Ui/templates/entity/view/course-page.twig
+++ b/src/module/Ui/templates/entity/view/course-page.twig
@@ -27,6 +27,7 @@
 </div>
 <div class="row">
     <div class="col-xs-12">
+        {% include 'entity/page/partials/alerts' %}
         {{ content }}
     </div>
 </div>


### PR DESCRIPTION
See #222 

This solution hides all the actions for trashed entities (including the dropdown). For articles, this works quite well. There are some open questions / stuff to do for courses, though:

* [ ] Hide only the actions for the specific course page when course page is trashed but show the actions for the whole course
* [ ] Trashing the whole course has no visible effect at all. But throws the same errors on editing the whole course. Any ideas for this?

Also: review remaining entity types like exercises.