### PR TITLE
WIP Multiple Choice / Single Choice exercises

### DIFF
--- a/src/module/Entity/config/types.config.php
+++ b/src/module/Entity/config/types.config.php
@@ -29,6 +29,53 @@ return [
                 ]
 
             ],
+            'choice-exercise' => [
+                'title' => 'id',
+                'description' => 'content',
+                'components' => [
+                    'repository' => [
+                        // no form yet
+                        'fields' => [
+                            'type', // MC or SC
+                            'content',
+                            'changes'
+                        ]
+                    ]
+                ],
+                'link' => [
+                    'children' => [
+                        'choice-exercise-choice' => [
+                            'multiple' => true
+                        ],
+                        'text-hint' => [
+                            'multiple' => false
+                        ]
+                    ]
+                ],
+                'license' => [],
+                'taxonomy' => []
+            ],
+            'choice-exercise-choice' => [
+                'title' => 'id',
+                'description' => 'answer',
+                'components' => [
+                    'repository' => [
+                        // no form yet
+                        'fields' => [
+                            'correct', // true or false
+                            'content',
+                            'changes'
+                        ]
+                    ]
+                ],
+                'link' => [
+                    'children' => [
+                        'text-hint' => [
+                            'multiple' => false
+                        ]
+                    ]
+                ]
+            ],
             'text-exercise'         => [
                 'title'       => 'id',
                 'description' => 'content',
@@ -238,7 +285,7 @@ return [
                     ],
                     'license'    => []
                 ]
-            ]
+            ],
         ]
     ]
 ];


### PR DESCRIPTION
First draft for the entity type for multiple choice / single choice exercises.

## New type `choice-exercise`

Represents a multiple choice / single choice exercise. It consists of three fields:
* `type` determines whether the exercise is MC or SC
* `content` for the assignment itself
* `changes` like other entities.

Moreover, it may have to types of children:
* one or more `choice-exercise-choice` that each represent a single choice
* one `text-hint` that represents a hint like in other types of exercises

## New type `choice-exercise-choise`

Represents a choice of a multiple choice / single choice exercise. It consists of three fields:
* `correct` states whether this choice is a correct solution or a wrong choice
* `content` for the content of the choice itself
* `changes` like other entities.

Moreover, it may have a `text-hint` child like in other types of exercises. We could use this for feedback and stuff. Maybe add a new type for this to make the difference to other hints clear.

Missing stuff:
* [ ] No forms yet (we have to decide whether we wait for the editor abstraction)
* [ ] No templates yet (design pending)
* [ ] Probably not everything right yet. E.g., the `choice-exercise-choice` should have a link to its parent (like `course-page`s do)

Feedback welcome!