### PR TITLE
WIP Add `text-input-solution` to `text-exercise`

### DIFF
--- a/src/module/Entity/config/types.config.php
+++ b/src/module/Entity/config/types.config.php
@@ -47,11 +47,27 @@ return [
                             ],
                             'text-hint'     => [
                                 'multiple' => false
+                            ],
+                            'text-input-solution' => [
+                                'multiple' => true
                             ]
                         ]
                     ],
                     'license'    => [],
                     'taxonomy'   => []
+                ]
+            ],
+            'text-input-solution' => [
+                'title' => 'id',
+                'description' => 'content',
+                'components' => [
+                    'repository' => [
+                        // no form yet
+                        'fields' => [
+                            'content',
+                            'validator'
+                        ]
+                    ]
                 ]
             ],
             'text-exercise-group'   => [


### PR DESCRIPTION
First draft for exercises that check the answer given by the user.

## New type `text-input-solution`

Represents a correct answer. It consists of two fields:
* `content` states the correct solution, e.g. `5`
* `validator` determines how the input of the user is validated. Some examples:
  * validator `exactlyTheSame`: Only accepts input that is exactly the same as the solution, e.g. `5` in this case.
  * validator `numberEquality`: Accepts input that has the same value, e.g. `5.0`, `10/2`.
  * validator `deviation`: Accepts input that is in some range of the solution, e.g. for deviation of 0.5: accepts everything between `4.5` and `5.5`.
  * ...
  * for the MVP, `exactlyTheSame` is probably enough.

## Add child `text-input-solution` to `text-exercise`

`text-exercises` may have one or more `text-input-solution`s. Each represents one (or possible more through validators) correct answers. We then check in the front end if the user input is correctly validates by one of the `text-input-solutions`. So for the MVP, you may add one or more `exactlyTheSame` answers.

Open things:
* [ ] Is this a logical way to represent solutions? I think that we need some kind of "validator"s (or whatever they will be named) for range of solutions. It would probably be nice if we could add validators dynamically with some kind of script language. Moreover, some validators may need arguments (like the `deviation` above). Altogether: I'm not sure whether this is a good way to do this. 
* [ ] Naming probably needs some improvements, too ;)

Missing stuff:
* [ ] No forms yet
* [ ] No templates yet
* [ ] Probably syntax is not correct, yet

Feedback welcome!