### PR TITLE
Add new subject `sustainability`

### DIFF
--- a/src/module/Subject/config/instances.config.php
+++ b/src/module/Subject/config/instances.config.php
@@ -66,7 +66,8 @@ return [
                 ],
                 'informatik'                   => [
                     'allowed_taxonomies' => [
-                        'topic'
+                        'topic',
+                        'locale'
                     ],
                     'allowed_entities'   => [
                         'article',
@@ -78,7 +79,21 @@ return [
                 ],
                 'chemie'                   => [
                     'allowed_taxonomies' => [
-                        'topic'
+                        'topic',
+                        'locale'
+                    ],
+                    'allowed_entities'   => [
+                        'article',
+                        'text-exercise',
+                        'video',
+                        'course',
+                        'text-exercise-group'
+                    ]
+                ],
+                'nachhaltigkeit'              => [
+                    'allowed_taxonomies' => [
+                        'topic',
+                        'locale'
                     ],
                     'allowed_entities'   => [
                         'article',
@@ -90,7 +105,8 @@ return [
                 ],
                 'permakultur'              => [
                     'allowed_taxonomies' => [
-                        'topic'
+                        'topic',
+                        'locale'
                     ],
                     'allowed_entities'   => [
                         'article',
@@ -140,6 +156,19 @@ return [
                         'course',
                         'text-exercise-group',
                         'math-puzzle'
+                    ]
+                ],
+                'sustainability' => [
+                    'allowed_taxonomies' => [
+                        'topic',
+                        'locale'
+                    ],
+                    'allowed_entities'   => [
+                        'article',
+                        'text-exercise',
+                        'video',
+                        'course',
+                        'text-exercise-group'
                     ]
                 ],
                 'permaculture' => [


### PR DESCRIPTION
ping @SimonKoehl 

As agreed upon in the email conversation, I added a new subject `sustainability` that should replace the current subject `permaculture`. Not sure if / what changes are necessary to the database.