### PR TITLE
Enable redirecting to parent in entity/view for some types - closes #363

### DIFF
--- a/src/module/Entity/config/types.config.php
+++ b/src/module/Entity/config/types.config.php
@@ -154,7 +154,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'multiple-choice-wrong-answer' => [
@@ -179,7 +182,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'multiple-choice-right-answer' => [
@@ -203,7 +209,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'single-choice-wrong-answer' => [
@@ -228,7 +237,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'single-choice-right-answer' => [
@@ -253,7 +265,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'input-string-normalized-match-challenge' => [
@@ -298,7 +313,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'input-number-exact-match-challenge' => [
@@ -343,7 +361,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'input-expression-equal-match-challenge' => [
@@ -388,7 +409,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'text-solution' => [
@@ -412,7 +436,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'video' => [
@@ -454,7 +481,10 @@ return [
                             ]
                         ]
                     ],
-                    'license' => []
+                    'license' => [],
+                    'redirect' => [
+                        'toType' => 'parent'
+                    ]
                 ]
             ],
             'article' => [

--- a/src/module/Entity/src/Entity/Controller/PageController.php
+++ b/src/module/Entity/src/Entity/Controller/PageController.php
@@ -36,9 +36,17 @@ class PageController extends AbstractController
         if ($type->hasComponent('redirect')) {
             /* @var $redirect RedirectOptions */
             $redirect = $type->getComponent('redirect');
-            foreach ($entity->getChildren('link', $redirect->getToType()) as $child) {
-                if (!$child->isTrashed() && $child->hasCurrentRevision()) {
-                    return $this->redirect()->toRoute('uuid/get', ['uuid' => $child->getId()]);
+
+            if ($redirect->getToType() === 'parent') {
+                $parent = $entity->getParents('link')->first();
+                if (!$parent->isTrashed() && $parent->hasCurrentRevision()) {
+                    return $this->redirect()->toRoute('uuid/get', ['uuid' => $parent->getId()]);
+                }
+            } else {
+                foreach ($entity->getChildren('link', $redirect->getToType()) as $child) {
+                    if (!$child->isTrashed() && $child->hasCurrentRevision()) {
+                        return $this->redirect()->toRoute('uuid/get', ['uuid' => $child->getId()]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
I added the possibility to redirect to the parent. Please take a look if it's OK to use the already existing "toType" parameter, even though "parent" is actually not a type.

The redirecting happens for:
- grouped-text-exercise
- SC/MC answers
- input exercises
- solution
- hint

Also, is a multiple redirect a problem? Because for example a solution of grouped-text-exercise redirects to the grouped-text-exercise which redirects to the exercise-group.