### PR TITLE
fixes #348 - course page sorting

### DIFF
--- a/src/module/Ui/templates/entity/view/partials/actions/link/sort.twig
+++ b/src/module/Ui/templates/entity/view/partials/actions/link/sort.twig
@@ -1,5 +1,5 @@
 {% set options = entity().getOptions(entity) %}
-{% if options.hasComponent('link') %}
+{% if options.hasComponent('link') and entity.getChildren('link').count() != 0 %}
     {% if isGranted('entity.link.order', entity) %}
         <li>
             <a rel="nofollow" href="{{ url('entity/link/order', {'entity': entity.getId(), 'type': 'link'}) }}">


### PR DESCRIPTION
Only display sort action in elements with children.