### PR TITLE
fixes #509 - Mathjax broken

### DIFF
--- a/src/module/Ui/templates/layout/partials/mathjax.phtml
+++ b/src/module/Ui/templates/layout/partials/mathjax.phtml
@@ -31,5 +31,6 @@
         }
     });
 </script>
-<script type="text/javascript"
-        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML&locale=<?php echo $this->currentLanguage(); ?>"></script>
+<script type="text/javascript" async
+        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML&locale=<?php echo $this->currentLanguage(); ?>">
+</script>


### PR DESCRIPTION
changed CDN to cloudflare as described in https://www.mathjax.org/cdn-shutting-down/