### PR TITLE
 closes #208 - add GA-Opt-out to privacy policy

### DIFF
--- a/src/assets/source/scripts/ATHENE2.js
+++ b/src/assets/source/scripts/ATHENE2.js
@@ -6,7 +6,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link        https://github.com/serlo-org/athene2 for the canonical source repository
  */
-/*global define, require, MathJax*/
+/*global define, require, MathJax, gaOptout*/
 define("ATHENE2", ['jquery', 'underscore', 'common', 'side_navigation', 'mobile_navigation', 'breadcrumbs', 'translator', 'side_element', 'content', 'system_notification',
                    'moment', 'ajax_overlay', 'tracking', 'autosize', 'toggle_action', 'modals', 'trigger', 'sortable_list',
                    'timeago', 'spoiler', 'injections', 'moment_de', 'forum_select', 'slider', 'math_puzzle', 'input_challenge', 'single_choice', 'multiple_choice',
@@ -194,6 +194,13 @@ define("ATHENE2", ['jquery', 'underscore', 'common', 'side_navigation', 'mobile_
             }());
 
             SideElement.init();
+
+            $('a[href=ga-opt-out]').click(function (e) {
+                e.preventDefault();
+                gaOptout();
+                SystemNotification.notify(t("Successfully deactivated Google Analytics"), "success");
+                window.scrollTo(0, 0);
+            });
 
             new Tracking($context);
         }

--- a/src/config/autoload/serlo.config.local.php.dist
+++ b/src/config/autoload/serlo.config.local.php.dist
@@ -30,6 +30,8 @@ return [
             'deutsch' => [
                 'code' => <<<EOL
 <script type="text/javascript">
+var disableStr='ga-disable-UA-20283862-3';if(document.cookie.indexOf(disableStr+'=true')>-1){window[disableStr]=true;}
+function gaOptout(){document.cookie=disableStr+'=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';window[disableStr]=true;}
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -47,6 +49,8 @@ EOL
             'english' => [
                 'code' => <<<EOL
 <script type="text/javascript">
+var disableStr='ga-disable-UA-20283862-3';if(document.cookie.indexOf(disableStr+'=true')>-1){window[disableStr]=true;}
+function gaOptout(){document.cookie=disableStr+'=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';window[disableStr]=true;}
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
In the Privacy-Policy a link to `ga-opt-out` has to be added, e.g. like this: `[Deactivate Google-Analytics](ga-opt-out)`

Implementation follows the example at https://developers.google.com/analytics/devguides/collection/gajs/#disable