### PR TITLE
Rename subject sex-ed to sex education

### DIFF
--- a/src/module/Subject/config/instances.config.php
+++ b/src/module/Subject/config/instances.config.php
@@ -236,7 +236,7 @@ return [
                         'text-exercise-group'
                     ]
                 ],
-                'sex-ed' => [
+                'sex education' => [
                     'allowed_taxonomies' => [
                         'topic',
                         'locale'


### PR DESCRIPTION
Fixes error on https://en.serlo.org/sex-education/some-topic (had some wrong assumptions about how the subject id is used). @arekkas Spaces in subject id are okay?