### PR TITLE
assets: make use of viewHelpers explicit

### DIFF
--- a/src/module/Ui/templates/editor/layout.phtml
+++ b/src/module/Ui/templates/editor/layout.phtml
@@ -13,7 +13,10 @@ echo $this->doctype();
 <html class="old-ie fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!-->
 <html class="fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <!--<![endif]-->
-<?php print $this->partial('layout/partials/head'); ?>
+<head>
+    <?php print $this->partial('layout/partials/head'); ?>
+    <link href="/assets/editor_styles.css" rel="stylesheet">
+</head>
 <body>
 <div class="panel panel-primary" id="editor-main-panel">
     <header class="panel-heading">
@@ -54,10 +57,7 @@ echo $this->doctype();
 </div>
 
 <?php echo $this->partial('layout/partials/default-modal'); ?>
-<?php echo $this->headScript(); ?>
-<?php echo $this->partial('layout/partials/mathjax'); ?>
-<?php echo $this->inlineScript(); ?>
-<?php echo $this->tracking(); ?>
+<?php echo $this->partial('editor/partials/scripts'); ?>
 <?php echo $this->twigPartial('editor/partials/video-modal'); ?>
 
 </body>

--- a/src/module/Ui/templates/editor/partials/scripts.phtml
+++ b/src/module/Ui/templates/editor/partials/scripts.phtml
@@ -1,0 +1,4 @@
+<script src="/assets/libs.js" type="text/javascript"></script>
+<script src="/assets/editor_scripts.js" type="text/javascript"></script>
+<?php echo $this->partial('layout/partials/mathjax'); ?>
+<?php echo $this->tracking(); ?>

--- a/src/module/Ui/templates/layout/1-col.phtml
+++ b/src/module/Ui/templates/layout/1-col.phtml
@@ -10,7 +10,9 @@
 echo $this->doctype();
 ?>
 <html class="fuelux" lang="<?php echo $this->currentLanguage(); ?>">
-<?php echo $this->partial('layout/partials/head'); ?>
+<head>
+    <?php print $this->partial('layout/partials/head'); ?>
+</head>
 <body itemscope itemtype="http://schema.org/WebPage">
 <div class="wrap">
     <?php echo $this->partial('layout/partials/header'); ?>

--- a/src/module/Ui/templates/layout/2-col.phtml
+++ b/src/module/Ui/templates/layout/2-col.phtml
@@ -13,7 +13,9 @@ echo $this->doctype();
 <html class="old-ie fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!-->
 <html class="fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <!--<![endif]-->
-<?php print $this->partial('layout/partials/head'); ?>
+<head>
+    <?php print $this->partial('layout/partials/head'); ?>
+</head>
 <body itemscope itemtype="http://schema.org/WebPage">
 <div class="wrap has-navigation ">
     <?php echo $this->partial('layout/partials/header'); ?>

--- a/src/module/Ui/templates/layout/3-col.phtml
+++ b/src/module/Ui/templates/layout/3-col.phtml
@@ -13,7 +13,9 @@ echo $this->doctype();
 <html class="old-ie fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!-->
 <html class="fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <!--<![endif]-->
-<?php print $this->partial('layout/partials/head'); ?>
+<head>
+    <?php print $this->partial('layout/partials/head'); ?>
+</head>
 <body itemscope itemtype="http://schema.org/WebPage">
 <div class="wrap has-navigation has-context">
     <?php echo $this->partial('layout/partials/header'); ?>

--- a/src/module/Ui/templates/layout/de/serlo-home.phtml
+++ b/src/module/Ui/templates/layout/de/serlo-home.phtml
@@ -11,8 +11,9 @@
 echo $this->doctype();
 ?>
 <html class="fuelux" lang="<?php echo $this->currentLanguage(); ?>">
-<?php echo $this->partial('layout/partials/head'); ?>
-
+<head>
+    <?php echo $this->partial('layout/partials/head'); ?>
+</head>
 <body class="serlo-home serlo-de-home" itemscope itemtype="http://schema.org/WebPage">
 <div class="wrap">
     <header id="header">

--- a/src/module/Ui/templates/layout/en/serlo-home.phtml
+++ b/src/module/Ui/templates/layout/en/serlo-home.phtml
@@ -11,8 +11,9 @@
 echo $this->doctype();
 ?>
 <html class="fuelux" lang="<?php echo $this->currentLanguage(); ?>">
-<?php echo $this->partial('layout/partials/head'); ?>
-
+<head>
+    <?php echo $this->partial('layout/partials/head'); ?>
+</head>
 <body class="serlo-home serlo-en-home" itemscope itemtype="http://schema.org/WebPage">
 <div class="wrap">
     <header id="header">

--- a/src/module/Ui/templates/layout/html.phtml
+++ b/src/module/Ui/templates/layout/html.phtml
@@ -1,6 +1,6 @@
 <?php
 /**
- * 
+ *
  * Athene2 - Advanced Learning Resources Manager
  *
  * @author	Aeneas Rekkas (aeneas.rekkas@serlo.org)
@@ -12,11 +12,11 @@ echo $this->doctype();
 ?>
 <!--[if lt IE 9 ]>    <html class="old-ie fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--> <html class="fuelux" lang="<?php echo $this->currentLanguage(); ?>"> <!--<![endif]-->
-<?php print $this->partial('layout/partials/head'); ?>
-
+<head>
+    <?php print $this->partial('layout/partials/head'); ?>
+</head>
 <!-- @deprecated -->
 <!-- moved to 2-col -->
-
 <body itemscope itemtype="http://schema.org/WebPage">
     <div class="wrap">
     	<?php echo $this->partial('layout/partials/header'); ?>

--- a/src/module/Ui/templates/layout/partials/footer.phtml
+++ b/src/module/Ui/templates/layout/partials/footer.phtml
@@ -32,7 +32,6 @@
         </div>
     </nav>
 </footer>
-<?php echo $this->headScript(); ?>
-<?php echo $this->partial('layout/partials/mathjax'); ?>
+
+<?php echo $this->partial('layout/partials/scripts'); ?>
 <?php /* echo $this->partial('layout/partials/popup'); */ ?>
-<?php echo $this->inlineScript(); ?>

--- a/src/module/Ui/templates/layout/partials/head.phtml
+++ b/src/module/Ui/templates/layout/partials/head.phtml
@@ -1,10 +1,6 @@
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <?php echo $this->headTitle($this->brand()->getHeadTitle(true))->setSeparator(' » '); ?>
-    <?php echo $this->headMeta(); ?>
-    <?php echo $this->headStyle(); ?>
-    <?php echo $this->headLink(['rel' => 'icon', 'href' => '/favicon.ico', 'type' => 'image/x-icon']); ?>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700,600" rel="stylesheet">
-    <link href='https://fonts.googleapis.com/css?family=Droid+Serif' rel='stylesheet' type='text/css'>
-</head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<?php echo $this->headTitle($this->brand()->getHeadTitle(true))->setSeparator(' » '); ?>
+<?php echo $this->headMeta(); ?>
+<?php echo $this->headLink(['rel' => 'icon', 'href' => '/favicon.ico', 'type' => 'image/x-icon']); ?>
+<?php echo $this->partial('layout/partials/styles'); ?>

--- a/src/module/Ui/templates/layout/partials/scripts.phtml
+++ b/src/module/Ui/templates/layout/partials/scripts.phtml
@@ -1,0 +1,4 @@
+<script src="/assets/libs.js" type="text/javascript"></script>
+<script src="/assets/scripts.js" type="text/javascript"></script>
+<?php echo $this->partial('layout/partials/mathjax'); ?>
+<?php /* echo $this->partial('layout/partials/popup'); */ ?>

--- a/src/module/Ui/templates/layout/partials/styles.phtml
+++ b/src/module/Ui/templates/layout/partials/styles.phtml
@@ -1,0 +1,2 @@
+<link href="/assets/styles.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700,600|Droid+Serif" rel="stylesheet">


### PR DESCRIPTION
Still uses assetic to bundle / compile / copy the files (since this also does some renaming and path rewriting), but makes `<script>` and `<link>` explicit so we can do some conditional importing for #556. As soon as #556 is done, we can remove assetic completely.
