### PR TITLE
fix: can't set navigation element position

### DIFF
--- a/src/module/Navigation/src/Navigation/Controller/NavigationController.php
+++ b/src/module/Navigation/src/Navigation/Controller/NavigationController.php
@@ -272,7 +272,9 @@ class NavigationController extends AbstractActionController
         $this->assertGranted('navigation.manage', $page);
         $this->pageForm->bind($page);
         if ($this->getRequest()->isPost()) {
-            $data = $this->params()->fromPost();
+            $data = array_merge($this->params()->fromPost(), [
+                'parent' => $this->params('parent', null)
+            ]);
             $this->pageForm->setData($data);
             if ($this->pageForm->isValid()) {
                 $this->navigationManager->updatePage($this->pageForm);


### PR DESCRIPTION
fixes #545 

solution uses the same way to account for empty POST data as in other actions of the navigation controller, e.g. https://github.com/serlo-org/athene2/blob/d8468f179ac8234f80925c277528f6fe7af32b40/src/module/Navigation/src/Navigation/Controller/NavigationController.php#L104-L107