### PR TITLE
SEO: replace some headings with hX classnames

### DIFF
--- a/src/module/Ui/templates/entity/page/aggregate/taxonomy.twig
+++ b/src/module/Ui/templates/entity/page/aggregate/taxonomy.twig
@@ -1,7 +1,7 @@
 <div class="sidebar-content-group">
     <ul class="nav nav-aside">
         <li class="nav-aside-header">
-            <h4>{% trans %} Related taxonomies {% endtrans %}</h4>
+            <span class="h4">{% trans %} Related taxonomies {% endtrans %}</span>
         </li>
         {% for term in terms if term.getTaxonomy.getName() in ['topic', 'topic-folder'] %}
            <li itemprop="relatedLink">{{ normalize().toAnchor(term) }}</li>

--- a/src/module/Ui/templates/entity/view/course-page.twig
+++ b/src/module/Ui/templates/entity/view/course-page.twig
@@ -10,10 +10,10 @@
         <div class="col-xs-12">
             <div class="icon-link">
                 <a href="{{ normalize().toUrl(previous) }}">
-                    <h4>
+                    <span class="h4">
                         <i class="fa fa-arrow-circle-left fa-2x"></i>
                         &ensp;<span>{{ previous.getCurrentRevision().get('title') }}</span>
-                    </h4>
+                    </span>
                 </a>
             </div>
         </div>
@@ -37,10 +37,10 @@
             <div class="pull-right">
                 <div class="icon-link icon-link-lower">
                     <a href="{{ normalize().toUrl(next) }}">
-                        <h4>
+                        <span class="h4">
                             <span>{{ next.getCurrentRevision().get('title') }}</span>&ensp;
                             <i class="fa fa-arrow-circle-right fa-2x"></i>
-                        </h4>
+                        </span>
                     </a>
                 </div>
             </div>

--- a/src/module/Ui/templates/related-content/view.phtml
+++ b/src/module/Ui/templates/related-content/view.phtml
@@ -5,7 +5,7 @@
             <?php foreach ($this->aggregated as $related): ?>
                 <?php if ($related->getType() == 'category'): ?>
                     <li class="nav-aside-header">
-                        <h4><?php echo $related->getTitle(); ?></h4>
+                        <span class="h4"><?php echo $related->getTitle(); ?></span>
                     </li>
                 <?php elseif ($related->getType() == 'internal'): ?>
                     <li>

--- a/src/module/Ui/templates/taxonomy/term/templates/partials/entities.twig
+++ b/src/module/Ui/templates/taxonomy/term/templates/partials/entities.twig
@@ -10,7 +10,7 @@
                     <span class="fa h2 fa-2x fa-{{ cycle(['graduation-cap', 'newspaper-o', 'play-circle', 'cubes'], i) }}"></span>
                 </div>
                 <div class="col-xs-10">
-                    <h2>{{ cycle(['Courses' | trans, 'Articles' | trans, 'Videos' | trans, 'Applets' | trans], i) }}</h2>
+                    <div class="h2">{{ cycle(['Courses' | trans, 'Articles' | trans, 'Videos' | trans, 'Applets' | trans], i) }}</div>
                     {% for link in types.get(type) %}
                         <div class="row">
                             <div class="col-xs-12">
@@ -25,7 +25,7 @@
     <div>
         {% if types.get('text-exercise') or types.get('text-exercise-group') or types.get('math-puzzle') %}
             <!-- Rest -->
-            <h2 class="heading-content" style="margin-bottom:30px">{% trans %} Exercises {% endtrans %}</h2>
+            <div class="h2 heading-content" style="margin-bottom:30px">{% trans %} Exercises {% endtrans %}</div>
             <div class="row top-buffer-10">
                 <div class="col-xs-12">
                     {% for entity in entities if entity.getType().getName() in ['text-exercise', 'text-exercise-group', 'math-puzzle'] %}


### PR DESCRIPTION
- removes headings from related content - fixes #685, 
- removes headings from course page back links - fixes #684, 
- removes headings from taxonomy overview - fixes #278 