### PR TITLE
feat: add cloudflare workers for semantic filenames

### DIFF
--- a/cloudflare-workers.js
+++ b/cloudflare-workers.js
@@ -1,0 +1,24 @@
+addEventListener('fetch', event => {
+    event.respondWith(handleRequest(event.request))
+})
+
+async function handleRequest(request) {
+    return (
+        (await handleSemanticAssetsFilenames(request)) || (await fetch(request))
+    )
+}
+
+async function handleSemanticAssetsFilenames(request) {
+    const re = /^https:\/\/assets.serlo.org\/(legacy\/|)(\w+)\/([\w\-\+]+)\.(\w+)$/
+    const match = request.url.match(re)
+
+    if (!match) {
+        return null
+    }
+
+    const [_url, prefix, hash, name, extension] = match
+    return await fetch(
+        `https://assets.serlo.org/${prefix}${hash}.${extension}`,
+        request
+    )
+}


### PR DESCRIPTION
Closes #647. Rewrites the urls as discussed in the issue. The newly created `cloudflare-workers.js` has to be inserted into www.cloudflare.com but it's here so that we have a file history.