### PR TITLE
fix: edit existing sub-entities without revision with old editor

### DIFF
--- a/src/module/Ui/templates/entity/view/partials/actions/link/add.twig
+++ b/src/module/Ui/templates/entity/view/partials/actions/link/add.twig
@@ -27,7 +27,7 @@
             {% elseif not(allowsManyChildren) and count == 1 and not child.isTrashed() and not child.hasCurrentRevision()
                     and isGranted('entity.revision.create', child) %}
                 <li>
-                    <a rel="nofollow" href="{{  url('entity/repository/add-revision', {'entity': child.getId()}) }}">
+                    <a rel="nofollow" href="{{  url('entity/repository/add-revision-old', {'entity': child.getId()}) }}">
                         <span class="fa fa-plus"></span>
                         {% trans %}
                         Add {{ type }}


### PR DESCRIPTION
missed an edit button for slow enrollement of new editor