### PR TITLE
fix: site breaking on unrevised exercises

### DIFF
--- a/src/module/Entity/src/Entity/View/Helper/EntityHelper.php
+++ b/src/module/Entity/src/Entity/View/Helper/EntityHelper.php
@@ -47,7 +47,7 @@ class EntityHelper extends AbstractHelper
     {
         return $entities->filter(
             function (EntityInterface $e) {
-                if ($this->getView()->isGranted('login')) {
+                if ($this->getView()->isGranted('login') && in_array($e->getType()->getName(), ['course', 'article', 'video', 'applet'])) {
                     $unrevised = ($e->hasHead() && $e->isUnrevised());
                     return !$e->isTrashed() && ($e->hasCurrentRevision() || $unrevised);
                 } else {

--- a/src/module/Ui/templates/entity/page/pending.twig
+++ b/src/module/Ui/templates/entity/page/pending.twig
@@ -2,7 +2,6 @@
 {% if entity.getHead() %}
     {% set head = entity.getHead() %}
     {% set title = head.get('title') %}
-    {% set content = entity().isOryEditorFormat(entity.getCurrentRevision()) ? oryRenderer() : markdown() %}
     {% set convert = false %}
 {% else %}
     {% set convert = true %}
@@ -10,7 +9,7 @@
 {% do headTitle(entity.getId()) %}
 <div class="page-header">
     <div class="pull-right btn-group hidden-xs">
-        {% include 'entity/view/partials/actions/controls' %}
+        {% include 'entity/view/partials/actions/controls' with {'entity' : entity, 'convert' : convert} %}
     </div>
     <h1>
         {% if title %}
@@ -21,8 +20,7 @@
             {{ entity.getId() }} <small>{{ 'Dead node' | trans }}</small>
         {% endif %}
     </h1>
-    {% set controls = include('entity/view/partials/actions/big') %}
-    {% do placeholder('controls').set(controls) %}
+    {% include('entity/view/partials/actions/big') with {'entity' : entity, 'convert' : convert} %}
 </div>
 {% include 'entity/page/partials/alerts' %}
 <div class="panel panel-danger">


### PR DESCRIPTION
- Allow only some entity types to be visible in taxonomy (Only course, article, video, and applet) - this bug was introduced by #699 (also see issue #680 )
-  Remove unecessary call to renderer in pending page and make some parameters explicit (just for codestyle, because I got confused, why we need the `convert=false` stuff.