### PR TITLE
speed up recycle bin and sort by timestamp

### DIFF
--- a/src/module/Ui/templates/uuid/recycle-bin.phtml
+++ b/src/module/Ui/templates/uuid/recycle-bin.phtml
@@ -1,20 +1,24 @@
-<?php echo $this->pageHeader('Uuid recycle bin')->render(); ?>
+<?php echo $this->pageHeader('Uuid recycle bin')->setSubtitle($this->translate('Page') . $this->elements->getCurrentPageNumber())->render(); ?>
 <table class="table">
     <thead>
         <tr>
             <th><?php echo $this->translate('ID'); ?></th>
             <th><?php echo $this->translate('Title'); ?></th>
             <th><?php echo $this->translate('Type'); ?></th>
+            <th><?php echo $this->translate('Timestamp') ?></th>
             <th><?php echo $this->translate('Actions'); ?></th>
         </tr>
     </thead>
     <tbody>
-        <?php /* @var $entity \Uuid\Entity\UuidHolder */ ?>
-        <?php foreach($this->entities as $entity): ?>
+        <?php foreach($this->elements as $element): ?>
+        <?php /* @var $entity \Uuid\Entity\UuidInterface */ ?>
+        <?php $entity = $element["entity"]; ?>
+        <?php $date = $element["date"]; ?>
             <tr>
-                <td><?php echo $this->normalize()->toTitle($entity); ?></td>
+                <td><?php echo $entity->getId() ?></td>
                 <td><?php echo $this->normalize()->toAnchor($entity); ?></td>
                 <td><?php echo $this->translate($this->normalize()->toType($entity)); ?></td>
+                <td><?php echo $this->timeago()->render($date); ?></td>
                 <td>
                     <div class="btn-group">
                         <?php if ($this->isGranted($this->uuid()->getPermission($entity, 'restore'), $entity)): ?>
@@ -39,3 +43,4 @@
         <?php endforeach; ?>
     </tbody>
 </table>
+<?php echo $this->paginationControl($this->elements, 'Sliding', 'common/paginator', ['route'=> 'uuid/recycle-bin']); ?>

--- a/src/module/Uuid/src/Uuid/Controller/UuidController.php
+++ b/src/module/Uuid/src/Uuid/Controller/UuidController.php
@@ -20,8 +20,9 @@ class UuidController extends AbstractActionController
 
     public function recycleBinAction()
     {
-        $entities = $this->getUuidManager()->findByTrashed(true);
-        $view     = new ViewModel(['entities' => $entities]);
+        $page        = $this->params()->fromQuery('page', 1);
+        $elements = $this->getUuidManager()->findByTrashed(true, $page);
+        $view     = new ViewModel(['elements' => $elements]);
         $view->setTemplate('uuid/recycle-bin');
         return $view;
     }

--- a/src/module/Uuid/src/Uuid/Factory/UuidManagerFactory.php
+++ b/src/module/Uuid/src/Uuid/Factory/UuidManagerFactory.php
@@ -31,6 +31,7 @@ class UuidManagerFactory implements FactoryInterface
         $moduleOptions        = $serviceLocator->get('Uuid\Options\ModuleOptions');
         $authorizationService = $this->getAuthorizationService($serviceLocator);
         $entityManager        = $this->getEntityManager($serviceLocator);
+//        $eventManager         = $serviceLocator->get('Event\EventManager');
         $classResolver        = $this->getClassResolver($serviceLocator);
         $uuidManager          = new UuidManager($authorizationService, $classResolver, $moduleOptions, $entityManager);
 

--- a/src/module/Uuid/src/Uuid/Manager/UuidManagerInterface.php
+++ b/src/module/Uuid/src/Uuid/Manager/UuidManagerInterface.php
@@ -11,6 +11,7 @@ namespace Uuid\Manager;
 use Common\ObjectManager\Flushable;
 use Doctrine\Common\Collections\Collection;
 use Uuid\Entity\UuidInterface;
+use Zend\Paginator\Paginator;
 
 interface UuidManagerInterface extends Flushable
 {
@@ -25,7 +26,7 @@ interface UuidManagerInterface extends Flushable
     public function findAll();
 
     /**
-     * Finds Uuuids by their trashed attribute.
+     * Finds Uuids by their trashed attribute.
      * <code>
      * $uuids = $um->findByTrashed(true);
      * foreach($uuids as $uuid)
@@ -35,9 +36,10 @@ interface UuidManagerInterface extends Flushable
      * </code>
      *
      * @param bool $trashed
-     * @return UuidInterface[]
+     * @param int $page
+     * @return Paginator
      */
-    public function findByTrashed($trashed);
+    public function findByTrashed($trashed, $page);
 
     /**
      * Get an Uuid.


### PR DESCRIPTION
Use paginator, so fewer elements get normalized (speeding up page load time) - closes #756

Also sorting by timestamp for more convenient access to currently deleted elements.