### PR TITLE
feature(Video): enable embedding videos from br-mediathek

### DIFF
--- a/src/module/Entity/src/Entity/Form/VideoForm.php
+++ b/src/module/Entity/src/Entity/Form/VideoForm.php
@@ -59,9 +59,9 @@ class VideoForm extends Form
                     [
                         'name'    => 'Regex',
                         'options' => [
-                            'pattern'  => '~^(https?:\/\/)?(.*?(youtube\.com\/watch\?v=.+|youtu\.be\/.+|vimeo\.com\/.+|upload\.wikimedia\.org\/.+(\.webm|\.ogg)?))~',
+                            'pattern'  => '~^(https?:\/\/)?(.*?(youtube\.com\/watch\?v=.+|youtu\.be\/.+|vimeo\.com\/.+|upload\.wikimedia\.org\/.+(\.webm|\.ogg)?|br\.de\/.+))~',
                             'messages' => [
-                                Regex::NOT_MATCH => 'Video-URL invalid, supported platforms are Youtube, Vimeo and Wikimedia Commons',
+                                Regex::NOT_MATCH => 'Video-URL invalid, supported platforms are Youtube, Vimeo, Wikimedia Commons and BR-Mediathek',
                             ],
                         ],
                     ],

--- a/src/module/Ui/templates/entity/view/video.twig
+++ b/src/module/Ui/templates/entity/view/video.twig
@@ -15,11 +15,15 @@
         {% elseif url matches '{^(https?:\\/\\/)?(.*?upload\\.wikimedia\\.org\\/.+)}'%}
             {% set src = url %}
             {% set type = 'wikimedia' %}
+        {% elseif url matches '{^(https?:\\/\\/)?(.*?br\\.de\\/.+)}' %}
+            {% set id = url | split('/') | last %}
+            {% set src = 'https://www.br.de/mediathek/embed/%s' | format(id) %}
+            {% set type = 'br' %}
         {% endif %}
 
         {% if src is defined %}
             <p class="embed-responsive embed-responsive-16by9">
-                {% if type == "wikimedia" %}
+                {% if type == 'wikimedia' %}
                     <video controls class="embed-responsive-item"
                         src="{{ src }}"></video>
                 {% else %}


### PR DESCRIPTION
closes #722 

Things for the future: Tagging the Video with the correct license atm has to be done manually after creation of the embed. We should discuss, if we want (and could) automate this.